### PR TITLE
修正浮點數計算錯誤

### DIFF
--- a/main.js
+++ b/main.js
@@ -125,7 +125,7 @@ function 顯示經驗與楓幣() {
 function 顯示擊殺總值() {
 	let 時間倍率 = (時間小時.value * 60 + 時間分鐘.value * 1) / 10;
 	for (let i = 0; i < 顯示.length; i++) {
-		顯示[i].擊殺html.innerHTML = 顯示[i].時間擊殺數 = 顯示[i].擊殺數 * 時間倍率;
+		顯示[i].擊殺html.innerHTML = 顯示[i].時間擊殺數 = Math.round(顯示[i].擊殺數 * 時間倍率);
 	}
 }
 


### PR DESCRIPTION
在顯示`擊殺數`（整數）時可能會出現浮點數誤差。

```javascript
3 * 0.1 === 0.30000000000000004
```

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/24631178/164286003-15e9f3e5-81b9-4db3-bb2b-544248de72e0.png">

所以將計算後的擊殺數四捨五入修復了這個問題
（也可以無條件捨去或是進位，但個人偏好四捨五入）

<img width="1674" alt="image" src="https://user-images.githubusercontent.com/24631178/164286634-06a6d316-d126-467e-827b-11d56370e753.png">
